### PR TITLE
⚡ Cache index.html to reduce server I/O

### DIFF
--- a/benchmarks/server_performance.js
+++ b/benchmarks/server_performance.js
@@ -1,0 +1,80 @@
+import http from 'http';
+import { app } from '../src/backend/server.js';
+import { performance } from 'perf_hooks';
+
+const PORT = 3001;
+let server;
+
+async function startServer() {
+  return new Promise((resolve) => {
+    server = app.listen(PORT, () => {
+      console.log(`Server listening on port ${PORT}`);
+      resolve();
+    });
+  });
+}
+
+async function runBenchmark() {
+  await startServer();
+
+  const numRequests = 1000;
+  const concurrentRequests = 10;
+  let completed = 0;
+  let totalTime = 0;
+
+  console.log(`Starting benchmark with ${numRequests} requests...`);
+  const startTime = performance.now();
+
+  const makeRequest = () => {
+    return new Promise((resolve, reject) => {
+      const reqStart = performance.now();
+      http.get(`http://localhost:${PORT}/`, (res) => {
+        let data = '';
+        res.on('data', (chunk) => data += chunk);
+        res.on('end', () => {
+          const reqEnd = performance.now();
+          totalTime += (reqEnd - reqStart);
+          resolve();
+        });
+      }).on('error', reject);
+    });
+  };
+
+  const pool = [];
+  for (let i = 0; i < concurrentRequests; i++) {
+    pool.push(Promise.resolve());
+  }
+
+  let index = 0;
+  async function worker() {
+    while (index < numRequests) {
+      index++;
+      await makeRequest();
+      completed++;
+      if (completed % 100 === 0) {
+        process.stdout.write(`Completed ${completed}/${numRequests}\r`);
+      }
+    }
+  }
+
+  await Promise.all(Array(concurrentRequests).fill(0).map(worker));
+
+  const endTime = performance.now();
+  const duration = endTime - startTime;
+  const avgTime = totalTime / numRequests;
+  const rps = numRequests / (duration / 1000);
+
+  console.log('\nBenchmark Results:');
+  console.log(`Total Requests: ${numRequests}`);
+  console.log(`Total Time: ${duration.toFixed(2)}ms`);
+  console.log(`Average Request Time: ${avgTime.toFixed(2)}ms`);
+  console.log(`Requests Per Second: ${rps.toFixed(2)}`);
+
+  server.close();
+  process.exit(0);
+}
+
+runBenchmark().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -183,27 +183,37 @@ app.get('/modules/TextGeometry.js', (req, res) => {
   );
 });
 
+const indexHtmlPath = path.join(__dirname, '..', 'frontend', 'index.html');
+let indexHtmlContent = null;
+
+try {
+  indexHtmlContent = fs.readFileSync(indexHtmlPath, 'utf8');
+} catch (err) {
+  log.error('Failed to preload index.html:', err);
+}
+
+const injectNonce = (html, nonce) => {
+  return html
+    .replace(/<script /g, `<script nonce="${nonce}" `)
+    .replace(/<style>/g, `<style nonce="${nonce}">`)
+    .replace(/<link rel="stylesheet"/g, `<link rel="stylesheet" nonce="${nonce}"`);
+};
+
 // Serve index.html with injected nonce
 const serveIndex = (req, res) => {
-  const indexHtmlPath = path.join(__dirname, '..', 'frontend', 'index.html');
+  if (indexHtmlContent) {
+    res.send(injectNonce(indexHtmlContent, res.locals.cspNonce));
+    return;
+  }
+
   fs.readFile(indexHtmlPath, 'utf8', (err, data) => {
     if (err) {
       log.error('Failed to read index.html:', err);
       res.status(500).send('Internal Server Error');
       return;
     }
-    // Inject nonces into all script and style tags
-    const injectedHtml = data.replace(
-      /<script /g,
-      `<script nonce="${res.locals.cspNonce}" `
-    ).replace(
-      /<style>/g,
-      `<style nonce="${res.locals.cspNonce}">`
-    ).replace(
-      /<link rel="stylesheet"/g,
-      `<link rel="stylesheet" nonce="${res.locals.cspNonce}"`
-    );
-    res.send(injectedHtml);
+    indexHtmlContent = data;
+    res.send(injectNonce(data, res.locals.cspNonce));
   });
 };
 


### PR DESCRIPTION
Implements in-memory caching for `index.html` in `src/backend/server.js`. 

Previously, `serveIndex` read the file from disk on every request. Now, it preloads the file content at startup (synchronously) or lazily on the first request (as a fallback). The CSP nonce injection logic was extracted to a helper function `injectNonce` and applied to the cached template string.

This change aims to reduce disk I/O contention. While local microbenchmarks showed minimal throughput difference (likely due to OS file caching), avoiding synchronous or repeated async I/O is a best practice for high-throughput node servers.

Also added `benchmarks/server_performance.js` to facilitate future server performance testing.

---
*PR created automatically by Jules for task [3205762036037158941](https://jules.google.com/task/3205762036037158941) started by @segin*