### PR TITLE
Remove ambiguous TODO in csg-worker.bundle.js

### DIFF
--- a/src/frontend/csg-worker.bundle.js
+++ b/src/frontend/csg-worker.bundle.js
@@ -1749,7 +1749,6 @@
     dot(v) {
       return this.x * v.x + this.y * v.y + this.z * v.z;
     }
-    // TODO lengthSquared?
     lengthSq() {
       return this.x * this.x + this.y * this.y + this.z * this.z;
     }


### PR DESCRIPTION
Removed a TODO comment that suggested renaming `lengthSq` to `lengthSquared` in the bundled Three.js code. Confirmed that `lengthSq` is the correct standard API and `lengthSquared` is unused.

---
*PR created automatically by Jules for task [17284009851129320891](https://jules.google.com/task/17284009851129320891) started by @segin*