### PR TITLE
⚡ Optimize Lathe primitive creation to avoid redundant allocations

### DIFF
--- a/benchmarks/lathe_bench.mjs
+++ b/benchmarks/lathe_bench.mjs
@@ -1,0 +1,85 @@
+import { JSDOM } from 'jsdom';
+
+// 1. Setup Environment
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+  url: 'http://localhost/',
+  pretendToBeVisual: true,
+  resources: 'usable'
+});
+
+global.window = dom.window;
+global.document = dom.window.document;
+// global.navigator = dom.window.navigator; // This throws error in some envs, let's use defineProperty
+Object.defineProperty(global, 'navigator', {
+  value: dom.window.navigator,
+  writable: true
+});
+global.HTMLElement = dom.window.HTMLElement;
+global.self = global.window;
+
+// Mock Canvas for Three.js
+global.HTMLCanvasElement = dom.window.HTMLCanvasElement;
+// Simple mock for getContext
+global.HTMLCanvasElement.prototype.getContext = function (type) {
+    if (type === 'webgl' || type === 'webgl2') {
+        return {
+            getParameter: () => 0,
+            createTexture: () => ({}),
+            createShader: () => ({}),
+            createProgram: () => ({}),
+            createBuffer: () => ({}),
+            getShaderPrecisionFormat: () => ({ rangeMin: 1, rangeMax: 1, precision: 1 }),
+            getExtension: () => null,
+            canvas: this
+        };
+    }
+    return null;
+};
+
+// Mock URL
+const originalURL = global.URL;
+global.URL = class MockURL extends originalURL {
+  static createObjectURL() { return 'blob:mock'; }
+  static revokeObjectURL() {}
+};
+
+// 2. Import PrimitiveManager
+// We need to import Three.js first to ensure it picks up the global window
+import * as THREE from 'three';
+import { PrimitiveManager } from '../src/frontend/PrimitiveManager.js';
+
+// 3. Run Benchmark
+async function runBenchmark() {
+    const scene = new THREE.Scene();
+    // Mock scene.add to avoid overhead unrelated to geometry creation
+    // However, _createMesh creates MeshPhongMaterial and Mesh, which have overhead.
+    // We want to measure that too as it's part of the function call, but mainly the Vector creation overhead.
+    // scene.add is just pushing to an array in Three.js, so it's fast.
+    // Let's keep scene.add normal or mocked to be a no-op to isolate addLathe logic.
+    scene.add = () => {};
+
+    const primitiveManager = new PrimitiveManager(scene);
+
+    const iterations = 10000;
+    const warmup = 100;
+
+    console.log(`Running benchmark with ${iterations} iterations...`);
+
+    // Warmup
+    for (let i = 0; i < warmup; i++) {
+        primitiveManager.addLathe();
+    }
+
+    // Measure
+    const start = performance.now();
+    for (let i = 0; i < iterations; i++) {
+        primitiveManager.addLathe();
+    }
+    const end = performance.now();
+
+    const totalTime = end - start;
+    console.log(`Total time: ${totalTime.toFixed(2)}ms`);
+    console.log(`Average time per call: ${(totalTime / iterations).toFixed(4)}ms`);
+}
+
+runBenchmark();

--- a/src/frontend/PrimitiveManager.js
+++ b/src/frontend/PrimitiveManager.js
@@ -3,6 +3,11 @@ import { TeapotGeometry } from 'three/examples/jsm/geometries/TeapotGeometry.js'
 import { FontLoader } from 'three/examples/jsm/loaders/FontLoader.js';
 import { TextGeometry } from 'three/examples/jsm/geometries/TextGeometry.js';
 
+const LATHE_POINTS = [];
+for (let i = 0; i < 10; i++) {
+  LATHE_POINTS.push(new THREE.Vector2(Math.sin(i * 0.2) * 0.5 + 0.5, (i - 5) * 0.2));
+}
+
 export class PrimitiveManager {
   constructor(scene) {
     this.scene = scene;
@@ -143,11 +148,7 @@ export class PrimitiveManager {
   }
 
   addLathe() {
-    const points = [];
-    for (let i = 0; i < 10; i++) {
-      points.push(new THREE.Vector2(Math.sin(i * 0.2) * 0.5 + 0.5, (i - 5) * 0.2));
-    }
-    const geometry = new THREE.LatheGeometry(points);
+    const geometry = new THREE.LatheGeometry(LATHE_POINTS);
     return this._createMesh(geometry, 0x00ff80); // Spring Green for Lathe
   }
 


### PR DESCRIPTION
💡 **What:**
Moved the `points` array generation in `PrimitiveManager.addLathe` to a module-level constant `LATHE_POINTS`.

🎯 **Why:**
Previously, `addLathe` created a new array and 10 new `THREE.Vector2` objects on every call. This optimization eliminates these unnecessary allocations, reducing garbage collection pressure.

📊 **Measured Improvement:**
A benchmark script `benchmarks/lathe_bench.mjs` was created to measure the execution time of 10,000 calls to `addLathe`.
- **Baseline:** ~395ms
- **Optimized:** ~388ms

While the raw CPU time improvement is minor (~1.6%) in a microbenchmark, the primary benefit is the reduction of object allocations (10 vectors per call), which improves long-term application stability and reduces GC pauses. Logic verification confirmed the geometry remains correct.

---
*PR created automatically by Jules for task [9618190282277218981](https://jules.google.com/task/9618190282277218981) started by @segin*